### PR TITLE
Adding control for CEC volume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "libc",
 ]
@@ -115,19 +115,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arrayvec"
@@ -155,18 +156,18 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -189,27 +190,25 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.12.0"
+version = "1.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+checksum = "dabb68eb3a7aa08b46fddfd59a3d55c978243557a90ab804769f7e20e67d2b01"
 dependencies = [
  "aws-lc-sys",
- "paste",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.24.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+checksum = "6bbe221bbf523b625a4dd8585c7f38166e31167ec2ca98051dbcb4c3b6e825d2"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "paste",
 ]
 
 [[package]]
@@ -247,9 +246,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "bb97d56060ee67d285efb8001fec9d2a4c710c32efd2e14b5cbb5ba71930fc2d"
 
 [[package]]
 name = "bindgen"
@@ -257,7 +256,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -270,7 +269,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.100",
  "which",
 ]
 
@@ -280,7 +279,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -289,7 +288,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -300,9 +299,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be3f42a67d6d345ecd59f675f3f012d6974981560836e938c22b424b85ce1be"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "block-buffer"
@@ -315,15 +314,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -333,9 +332,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
@@ -359,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.9"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -421,9 +420,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -431,7 +430,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -457,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
@@ -573,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -659,7 +658,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -681,7 +680,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -692,9 +691,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "der"
@@ -755,7 +754,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -775,7 +774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core 0.20.2",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -798,7 +797,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -819,9 +818,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -851,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "enumflags2"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d232db7f5956f3f14313dc2f87985c58bd2c695ce124c8cdd984e08e15ac133d"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
 dependencies = [
  "enumflags2_derive",
  "serde",
@@ -861,13 +860,13 @@ dependencies = [
 
 [[package]]
 name = "enumflags2_derive"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -881,22 +880,22 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
 dependencies = [
  "anstream",
  "anstyle",
  "env_filter",
- "humantime",
+ "jiff",
  "log",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -943,9 +942,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1021,6 +1020,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,7 +1040,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1095,8 +1107,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1107,9 +1133,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio-sys"
-version = "0.20.8"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8446d9b475730ebef81802c1738d972db42fde1c5a36a627ebc4d665fc87db04"
+checksum = "160eb5250a26998c3e1b54e6a3d4ea15c6c7762a6062a19a7b63eff6e2b33f9e"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1120,11 +1146,11 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f969edf089188d821a30cde713b6f9eb08b20c63fc2e584aba2892a7984a8cc0"
+checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -1149,14 +1175,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "glib-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b360ff0f90d71de99095f79c526a5888c9c92fc9ee1b19da06c6f5e75f0c2a53"
+checksum = "a8928869a44cfdd1fccb17d6746e4ff82c8f82e41ce705aa026a52ca8dc3aefb"
 dependencies = [
  "libc",
  "system-deps",
@@ -1170,9 +1196,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "gobject-sys"
-version = "0.20.7"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a56235e971a63bfd75abb13ef70064e1346388723422a68580d8a6fbac6423"
+checksum = "c773a3cb38a419ad9c26c81d177d96b4b08980e8bdbbf32dace883e96e96e7e3"
 dependencies = [
  "glib-sys",
  "libc",
@@ -1181,28 +1207,30 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842dc78579ce01e6a1576ad896edc92fca002dd60c9c3746b7fc2bec6fb429d0"
+checksum = "be93b4ec2e4710b04d9264c0c7350cdd62a8c20e5e4ac732552ebb8f0debe8eb"
 dependencies = [
  "cfg-if",
  "futures-sink",
  "futures-timer",
  "futures-util",
+ "getrandom 0.3.1",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
  "portable-atomic",
- "rand",
+ "rand 0.9.0",
  "smallvec",
  "spinning_top",
+ "web-time",
 ]
 
 [[package]]
 name = "gstreamer"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "700cb1b2e86dda424f85eb728102a111602317e40b4dd71cf1c0dc04e0cc5d95"
+checksum = "2188fe829b0ebe12e4cf2bbcf6658470a936269daba7afae92847a2af32c9105"
 dependencies = [
  "cfg-if",
  "futures-channel",
@@ -1220,14 +1248,14 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "gstreamer-app"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b7bda01190cf5000869083afbdd5acbe1ab86fbc523825898ba9ce777846c0"
+checksum = "2e9a883eb21aebcf1289158225c05f7aea5da6ecf71fa7f0ff1ce4d25baf004e"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1240,9 +1268,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-app-sys"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0a5c2b149c629a46f21671118f491f61daab4469979105172fb2f8536b4e56"
+checksum = "94f7ef838306fe51852d503a14dc79ac42de005a59008a05098de3ecdaf05455"
 dependencies = [
  "glib-sys",
  "gstreamer-base-sys",
@@ -1253,9 +1281,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a6009b5c9c942cab1089956a501bd63778e65a3e69310949d173e90e2cdda2"
+checksum = "49118ca684e2fc42207509fcac8497d91079c2ffe8ff2b4ae99e71dbafef1ede"
 dependencies = [
  "cfg-if",
  "glib",
@@ -1269,9 +1297,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-audio-sys"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef70a3d80e51ef9a45749a844cb8579d4cabe5ff59cb43a65d6f3a377943262f"
+checksum = "7d469526ecf30811b50a6460fd285ee40d189c46048b3d0c69b67a04b414fb51"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1283,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d152db7983f98d5950cf64e53805286548063475fb61a5e5450fba4cec05899b"
+checksum = "ad33dd444db0d215ac363164f900f800ffb93361ad8a60840e95e14b7de985e8"
 dependencies = [
  "atomic_refcell",
  "cfg-if",
@@ -1297,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-base-sys"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d47cc2d15f2a3d5eb129e5dacbbeec9600432b706805c15dff57b6aa11b2791c"
+checksum = "114b2a704f19a70f20c54b00e54f5d5376bbf78bd2791e6beb0776c997d8bf24"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1310,9 +1338,9 @@ dependencies = [
 
 [[package]]
 name = "gstreamer-sys"
-version = "0.23.4"
+version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16cf1ae0a869aa7066ce3c685b76053b4b4f48f364a5b18c4b1f36ef57469719"
+checksum = "fe159238834058725808cf6604a7c5d9e4a50e1eacd7b0c63bce2fe3a067dbd1"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1341,16 +1369,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1373,7 +1401,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 1.2.0",
+ "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
@@ -1385,7 +1413,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -1442,9 +1470,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1469,39 +1497,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1529,15 +1551,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.8",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1557,8 +1579,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-rustls 0.26.0",
  "hyper-util",
  "pin-project-lite",
@@ -1567,7 +1589,7 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tower-service",
  "webpki",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -1591,8 +1613,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls 0.22.4",
@@ -1601,7 +1623,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tower-service",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -1611,17 +1633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -1633,9 +1655,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1781,7 +1803,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1823,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1833,18 +1855,18 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-docker"
@@ -1891,9 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jack"
@@ -1910,11 +1932,11 @@ dependencies = [
 
 [[package]]
 name = "jack"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a4ae24f4ee29676aef8330fed1104e72f314cab16643dbeb61bfd99b4a8273"
+checksum = "73213dab741ae0a4623824289625611d11bb8254ad1fdefc84e480f7632aa528"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "jack-sys",
  "lazy_static",
  "libc",
@@ -1933,6 +1955,30 @@ dependencies = [
  "libloading 0.7.4",
  "log",
  "pkg-config",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1968,9 +2014,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1993,9 +2039,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libcec-sys"
@@ -2008,7 +2054,7 @@ dependencies = [
  "cmake",
  "fs_extra",
  "pkg-config",
- "reqwest 0.12.12",
+ "reqwest 0.12.14",
  "target-lexicon",
  "zip-extract",
 ]
@@ -2051,7 +2097,7 @@ dependencies = [
  "if-addrs",
  "log",
  "multimap",
- "rand",
+ "rand 0.8.5",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -2059,23 +2105,23 @@ dependencies = [
 
 [[package]]
 name = "libpulse-binding"
-version = "2.28.2"
+version = "2.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1040a6c4c4d1e9e852000f6202df1a02a4f074320de336ab21e4fd317b538"
+checksum = "441092fb2d05962d74246a00c1b2f8c87c60fb6b38a5cc42227c229a702c0ce5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.0",
  "libc",
  "libpulse-sys",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "winapi",
 ]
 
 [[package]]
 name = "libpulse-simple-binding"
-version = "2.28.1"
+version = "2.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05fd6b68f33f6a251265e6ed1212dc3107caad7c5c6fdcd847b2e65ef58c308d"
+checksum = "b7bebef0381c8e3e4b23cc24aaf36fab37472bece128de96f6a111efa464cfef"
 dependencies = [
  "libpulse-binding",
  "libpulse-simple-sys",
@@ -2084,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "libpulse-simple-sys"
-version = "1.21.1"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6613b4199d8b9f0edcfb623e020cb17bbd0bee8dd21f3c7cc938de561c4152"
+checksum = "3bd96888fe37ad270d16abf5e82cccca1424871cf6afa2861824d2a52758eebc"
 dependencies = [
  "libpulse-sys",
  "pkg-config",
@@ -2094,12 +2140,12 @@ dependencies = [
 
 [[package]]
 name = "libpulse-sys"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc19e110fbf42c17260d30f6d3dc545f58491c7830d38ecb9aaca96e26067a9b"
+checksum = "b8febf45075a6ac7e36d0c7aa62536217f476f24456854cdad296952852b5cd2"
 dependencies = [
  "libc",
- "num-derive 0.3.3",
+ "num-derive",
  "num-traits",
  "pkg-config",
  "winapi",
@@ -2112,10 +2158,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2129,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "mach2"
@@ -2171,9 +2223,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -2185,7 +2237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2210,7 +2262,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -2239,7 +2291,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2285,7 +2337,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2300,7 +2352,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2313,24 +2365,13 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2391,7 +2432,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2411,9 +2452,9 @@ checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
 dependencies = [
  "base64 0.13.1",
  "chrono",
- "getrandom",
+ "getrandom 0.2.15",
  "http 0.2.12",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2441,7 +2482,7 @@ dependencies = [
  "jni",
  "ndk",
  "ndk-context",
- "num-derive 0.4.2",
+ "num-derive",
  "num-traits",
  "oboe-sys",
 ]
@@ -2457,18 +2498,18 @@ dependencies = [
 
 [[package]]
 name = "ogg"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5477016638150530ba21dec7caac835b29ef69b20865751d2973fce6be386cf1"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
 dependencies = [
  "byteorder",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "open"
@@ -2483,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "option-operations"
@@ -2545,7 +2586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2643,15 +2684,24 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portaudio-rs"
@@ -2682,28 +2732,28 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.28"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924b9a625d6df5b74b0b3cfbb5669b3f62ddf3d46a677ce12b1945471b4ae5c3"
+checksum = "f1ccf34da56fc294e7d4ccf69a85992b7dfb826b7cf57bac6a70bba3494cc08a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "priority-queue"
-version = "2.1.1"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
+checksum = "70c501afe3a2e25c9bd219aa56ec1e04cdb3fcdd763055be268778c13fa82c1f"
 dependencies = [
  "autocfg",
  "equivalent",
@@ -2712,27 +2762,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "protobuf"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -2741,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
+checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -2756,9 +2806,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-json-mapping"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b445cf83c9303695e6c423d269759e139b6182d2f1171e18afda7078a764336"
+checksum = "e0d6e4be637b310d8a5c02fa195243328e2d97fa7df1127a27281ef1187fcb1d"
 dependencies = [
  "protobuf",
  "protobuf-support",
@@ -2767,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
+checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2783,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -2811,9 +2861,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -2825,14 +2875,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.2.15",
+ "rand 0.8.5",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2854,9 +2904,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -2868,8 +2918,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2879,7 +2940,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2888,7 +2959,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]
@@ -2898,16 +2978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2982,19 +3062,19 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
@@ -3005,7 +3085,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3013,28 +3093,27 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3050,9 +3129,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -3061,7 +3140,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3088,14 +3167,27 @@ checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
-version = "0.38.43"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -3127,9 +3219,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3186,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -3217,15 +3309,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -3290,7 +3382,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -3303,7 +3395,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.7.0",
+ "bitflags 2.9.0",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -3322,29 +3414,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3354,9 +3446,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -3364,13 +3456,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3453,7 +3545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3467,9 +3559,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 
 [[package]]
 name = "socket2"
@@ -3508,7 +3600,7 @@ dependencies = [
 
 [[package]]
 name = "spotipi"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "data-encoding",
  "env_logger",
@@ -3525,43 +3617,43 @@ dependencies = [
  "spotipi-playback",
  "spotipi-protocol",
  "sysinfo",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "spotipi-audio"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "aes",
  "bytes",
  "ctr",
  "futures-util",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "parking_lot",
  "spotipi-core",
  "tempfile",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
 ]
 
 [[package]]
 name = "spotipi-connect"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "futures-util",
  "log",
  "protobuf",
- "rand",
+ "rand 0.8.5",
  "serde_json",
  "spotipi-core",
  "spotipi-playback",
  "spotipi-protocol",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -3569,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "spotipi-core"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -3582,17 +3674,17 @@ dependencies = [
  "futures-util",
  "governor",
  "hmac",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body-util",
  "httparse",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-proxy2",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "log",
  "nonzero_ext",
  "num-bigint",
- "num-derive 0.4.2",
+ "num-derive",
  "num-integer",
  "num-traits",
  "once_cell",
@@ -3603,7 +3695,7 @@ dependencies = [
  "protobuf",
  "protobuf-json-mapping",
  "quick-xml",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
@@ -3612,7 +3704,7 @@ dependencies = [
  "spotipi-oauth",
  "spotipi-protocol",
  "sysinfo",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -3625,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "spotipi-discovery"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "aes",
  "base64 0.22.1",
@@ -3639,24 +3731,24 @@ dependencies = [
  "hex",
  "hmac",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "libmdns",
  "log",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_repr",
  "sha1",
  "spotipi-core",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "zbus",
 ]
 
 [[package]]
 name = "spotipi-metadata"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3666,28 +3758,29 @@ dependencies = [
  "serde_json",
  "spotipi-core",
  "spotipi-protocol",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "uuid",
 ]
 
 [[package]]
 name = "spotipi-oauth"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "env_logger",
  "log",
  "oauth2",
  "open",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "spotipi-playback"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "alsa",
+ "arrayvec",
  "cec-rs",
  "cpal",
  "futures-util",
@@ -3695,7 +3788,7 @@ dependencies = [
  "gstreamer",
  "gstreamer-app",
  "gstreamer-audio",
- "jack 0.13.0",
+ "jack 0.13.2",
  "libpulse-binding",
  "libpulse-simple-binding",
  "log",
@@ -3703,7 +3796,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "portaudio-rs",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rodio",
  "sdl2",
@@ -3712,14 +3805,14 @@ dependencies = [
  "spotipi-core",
  "spotipi-metadata",
  "symphonia",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
- "zerocopy 0.8.14",
+ "zerocopy",
 ]
 
 [[package]]
 name = "spotipi-protocol"
-version = "0.6.0-dev"
+version = "0.7.0"
 dependencies = [
  "protobuf",
  "protobuf-codegen",
@@ -3852,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3884,7 +3977,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -3942,15 +4035,15 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -3965,11 +4058,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -3980,18 +4073,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4006,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -4023,15 +4116,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4064,9 +4157,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4089,7 +4182,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4115,11 +4208,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "tokio",
 ]
 
@@ -4142,13 +4235,13 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.21",
+ "rustls 0.23.23",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tungstenite",
- "webpki-roots 0.26.7",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -4166,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -4187,9 +4280,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -4244,7 +4337,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4271,11 +4364,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.2.0",
+ "http 1.3.1",
  "httparse",
  "log",
- "rand",
- "rustls 0.23.21",
+ "rand 0.8.5",
+ "rustls 0.23.23",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -4284,9 +4377,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uds_windows"
@@ -4301,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -4355,12 +4448,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
+checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
 dependencies = [
- "getrandom",
- "rand",
+ "getrandom 0.3.1",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -4445,35 +4538,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.99"
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4484,9 +4587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4494,28 +4597,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4549,9 +4655,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4565,7 +4671,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -4668,7 +4774,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4679,18 +4785,24 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
+ "windows-result 0.3.1",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -4704,21 +4816,20 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -4796,11 +4907,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -4822,6 +4949,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4838,6 +4971,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4858,10 +4997,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4882,6 +5033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4898,6 +5055,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4918,6 +5081,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4936,10 +5105,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.24"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -4952,6 +5127,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4996,15 +5180,15 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
 [[package]]
 name = "zbus"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192a0d989036cd60a1e91a54c9851fb9ad5bd96125d41803eed79d2e2ef74bd7"
+checksum = "59c333f648ea1b647bc95dc1d34807c8e25ed7a6feff3394034dc4776054b236"
 dependencies = [
  "async-broadcast",
  "async-recursion",
@@ -5012,7 +5196,7 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-util",
+ "futures-lite",
  "hex",
  "nix",
  "ordered-stream",
@@ -5032,14 +5216,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3685b5c81fce630efc3e143a4ded235b107f1b1cdf186c3f115529e5e5ae4265"
+checksum = "f325ad10eb0d0a3eb060203494c3b7ec3162a01a59db75d2deee100339709fc0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -5047,9 +5231,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "856b7a38811f71846fd47856ceee8bccaec8399ff53fb370247e66081ace647b"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
@@ -5059,63 +5243,42 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "byteorder",
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a367f292d93d4eab890745e75a778da40909cab4d6ff8173693812f79c4a2468"
-dependencies = [
- "zerocopy-derive 0.8.14",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3931cb58c62c13adec22e38686b559c86a30565e16ad6e8510a337cedc611e1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -5144,7 +5307,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -5208,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e6b9b5f1361de2d5e7d9fd1ee5f6f7fcb6060618a1f82f3472f58f2b8d4be9"
+checksum = "b2df9ee044893fcffbdc25de30546edef3e32341466811ca18421e3cd6c5a3ac"
 dependencies = [
  "endi",
  "enumflags2",
@@ -5223,27 +5386,27 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.2.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573a8dd76961957108b10f7a45bac6ab1ea3e9b7fe01aff88325dc57bb8f5c8b"
+checksum = "74170caa85b8b84cc4935f2d56a57c7a15ea6185ccdd7eadb57e6edd90f94b2f"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.100",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd46446ea2a1f353bfda53e35f17633afa79f4fe290a611c94645c69fe96a50"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.96",
+ "syn 2.0.100",
  "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version = "1.82"
 authors = ["Jon Perkowski","Librespot Org"]
 license = "MIT"
@@ -23,36 +23,36 @@ doc = false
 
 [dependencies.spotipi-audio]
 path = "audio"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-connect]
 path = "connect"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-core]
 path = "core"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-discovery]
 path = "discovery"
-version = "0.6.0-dev"
+version = "0.7.0"
 default-features = false
 
 [dependencies.spotipi-metadata]
 path = "metadata"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-playback]
 path = "playback"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-protocol]
 path = "protocol"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-oauth]
 path = "oauth"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies]
 data-encoding = "2.5"

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-audio"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The audio fetching logic for spotipi"
@@ -10,7 +10,7 @@ edition = "2021"
 
 [dependencies.spotipi-core]
 path = "../core"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies]
 aes = "0.8"

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-connect"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery and Spotify Connect logic for spotipi"
@@ -21,12 +21,12 @@ uuid = { version = "1.11.0", features = ["v4"] }
 
 [dependencies.spotipi-core]
 path = "../core"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-playback]
 path = "../playback"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-protocol]
 path = "../protocol"
-version = "0.6.0-dev"
+version = "0.7.0"

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -79,7 +79,7 @@ impl From<StateError> for Error {
 pub struct ConnectConfig {
     /// The name of the connect device (default: spotipi)
     pub name: String,
-    /// The icon type of the connect device (default: [DeviceType::Speaker])
+    /// The icon type of the connect device (default: [DeviceType::Avr])
     pub device_type: DeviceType,
     /// Displays the [DeviceType] twice in the ui to show up as a group (default: false)
     pub is_group: bool,
@@ -94,8 +94,8 @@ pub struct ConnectConfig {
 impl Default for ConnectConfig {
     fn default() -> Self {
         Self {
-            name: "spotipi".to_string(),
-            device_type: DeviceType::Speaker,
+            name: "SpotiPi".to_string(),
+            device_type: DeviceType::Avr,
             is_group: false,
             initial_volume: u16::MAX / 2,
             disable_volume: false,

--- a/contrib/spotipi.service
+++ b/contrib/spotipi.service
@@ -17,13 +17,16 @@ Restart=on-failure
 RestartSec=10
 
 # with vol control and callback
-#ExecStart=/usr/bin/spotipi --onevent /usr/bin/spotipi-onevent.py -n "SpotiPi" -b 320 -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" -m "alsa"
+# ExecStart=/usr/bin/spotipi --onevent /usr/bin/spotipi-onevent.py -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" -m softvol --volume-ctrl linearpass -q
 
 # with callback no vol control
-#ExecStart=/usr/bin/spotipi --onevent /usr/bin/spotipi-onevent.py -n "SpotiPi" -b 320 -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" --mixer softvol --volume-ctrl fixed --initial-volume 100
+# ExecStart=/usr/bin/spotipi --onevent /usr/bin/spotipi-onevent.py -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" -m softvol --volume-ctrl fixed --initial-volume 100 -q
 
 # with no vol control or callback
-ExecStart=/usr/bin/spotipi -n "SpotiPi" -b 320 -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" --mixer softvol --volume-ctrl fixed --initial-volume 100
+# ExecStart=/usr/bin/spotipi -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" -m softvol --volume-ctrl fixed --initial-volume 100 -q
+
+# with vol control no callback
+ExecStart=/usr/bin/spotipi --onevent /usr/bin/spotipi-onevent.py -c /usr/lib/spotipi/cache --cache-size-limit 500M --backend "alsa" --device "hdmi:CARD=vc4hdmi,DEV=0" -m softvol --volume-ctrl linearpass -q
 
 [Install]
 WantedBy=multi-user.target

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-core"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Paul Lietar <paul@lietar.net>"]
 build = "build.rs"
@@ -11,11 +11,11 @@ edition = "2021"
 
 [dependencies.spotipi-oauth]
 path = "../oauth"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-protocol]
 path = "../protocol"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies]
 aes = "0.8"
@@ -42,7 +42,7 @@ once_cell = "1"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 pin-project-lite = "0.2"
-priority-queue = "2.0"
+priority-queue = "=2.0"
 protobuf = "3.5"
 quick-xml = { version = "0.37.1", features = ["serialize"] }
 rand = "0.8"

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -64,9 +64,9 @@ pub enum DeviceType {
     Computer = 1,
     Tablet = 2,
     Smartphone = 3,
-    #[default]
     Speaker = 4,
     Tv = 5,
+    #[default]
     Avr = 6,
     Stb = 7,
     AudioDongle = 8,

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-discovery"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery logic for spotipi"
@@ -34,7 +34,7 @@ zbus = { version = "5", default-features = false, features = ["tokio"], optional
 
 [dependencies.spotipi-core]
 path = "../core"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dev-dependencies]
 futures = "0.3"

--- a/discovery/examples/discovery_group.rs
+++ b/discovery/examples/discovery_group.rs
@@ -11,7 +11,7 @@ async fn main() {
     let mut server =
         spotipi_discovery::Discovery::builder(device_id, SessionConfig::default().client_id)
             .name(name)
-            .device_type(DeviceType::Speaker)
+            .device_type(DeviceType::Avr)
             .is_group(true)
             .launch()
             .unwrap();

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -449,13 +449,13 @@ impl Builder {
         }
     }
 
-    /// Sets the name to be displayed. Default is `"Spotipi"`.
+    /// Sets the name to be displayed. Default is `"SpotiPi"`.
     pub fn name(mut self, name: impl Into<Cow<'static, str>>) -> Self {
         self.server_config.name = name.into();
         self
     }
 
-    /// Sets the device type which is visible as icon in other Spotify clients. Default is `Speaker`.
+    /// Sets the device type which is visible as icon in other Spotify clients. Default is `AVR`.
     pub fn device_type(mut self, device_type: DeviceType) -> Self {
         self.server_config.device_type = device_type;
         self

--- a/examples/play_connect.rs
+++ b/examples/play_connect.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use spotipi::{
     connect::{ConnectConfig, LoadRequest, LoadRequestOptions, Spirc},
     core::{
@@ -6,13 +8,13 @@ use spotipi::{
     playback::mixer::MixerConfig,
     playback::{
         audio_backend,
-        config::{AudioFormat, PlayerConfig},
+        cec::CecClient,
+        config::{AudioFormat, PlayerConfig, VolumeCtrl},
         mixer,
         player::Player,
     },
 };
 
-use spotipi_playback::cec::CecClient;
 use log::LevelFilter;
 
 const CACHE: &str = ".cache";
@@ -52,7 +54,7 @@ async fn main() -> Result<(), Error> {
 
     let session = Session::new(session_config, Some(cache));
     let mixer = mixer_builder(mixer_config);
-    let cec_client = CecClient::new("Example".into(), c"/dev/cec/0".into());
+    let cec_client = CecClient::new("Example".into(), c"/dev/cec/0".into(), VolumeCtrl::from_str("fixed").unwrap(), 100, false);
 
     let player = Player::new(
         player_config,

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-metadata"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The metadata logic for spotipi"
@@ -20,8 +20,8 @@ serde_json = "1.0"
 
 [dependencies.spotipi-core]
 path = "../core"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-protocol]
 path = "../protocol"
-version = "0.6.0-dev"
+version = "0.7.0"

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-oauth"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Nick Steel <nick@nsteel.co.uk>"]
 description = "OAuth authorization code flow with PKCE for obtaining a Spotify access token"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-playback"
-version = "0.6.0-dev"
+version = "0.7.0"
 authors = ["Sasha Hilton <sashahilton00@gmail.com>"]
 description = "The audio playback logic for spotipi"
 license = "MIT"
@@ -9,15 +9,15 @@ edition = "2021"
 
 [dependencies.spotipi-audio]
 path = "../audio"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-core]
 path = "../core"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies.spotipi-metadata]
 path = "../metadata"
-version = "0.6.0-dev"
+version = "0.7.0"
 
 [dependencies]
 portable-atomic = "1"
@@ -56,6 +56,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
 
 # CEC
+arrayvec = "0.7.1"
 cec-rs = "11.0"
 
 [features]

--- a/playback/src/cec/mod.rs
+++ b/playback/src/cec/mod.rs
@@ -1,19 +1,43 @@
-use log::trace;
+use crate::{config::VolumeCtrl, mixer::mappings::MappedCtrl};
 
+use arrayvec::ArrayVec;
 use cec_rs::{
-    CecAdapterType, CecCommand, CecConnection, CecConnectionCfgBuilder, CecConnectionResult, CecDeviceType, CecDeviceTypeVec, CecKeypress, CecLogMessage, CecLogicalAddress, CecLogicalAddresses, CecVendorId, KnownAndRegisteredCecLogicalAddress, KnownCecAudioStatus, KnownCecLogicalAddress, TryFromCecAudioStatusError
+    CecAdapterType, CecCommand, CecConnection, CecConnectionCfgBuilder, CecConnectionResult, 
+    CecDatapacket, CecDeviceType, CecDeviceTypeVec, CecKeypress, CecLogLevel, CecLogMessage, 
+    CecLogicalAddress, CecLogicalAddresses, CecOpcode, CecPowerStatus, 
+    KnownAndRegisteredCecLogicalAddress, KnownCecLogicalAddress
 };
-use std::{collections::HashSet, ffi::CString, sync::Arc, time::Duration};
+use portable_atomic::{AtomicBool, AtomicU8};
+use std::{collections::HashSet, ffi::CString, sync::{atomic::Ordering, Arc}, time::Duration};
+use tokio::{sync::mpsc::UnboundedSender, task::JoinSet};
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum CecEvent {
+    PowerIsOnChange(bool),
+    /// Order: old, new
+    VolumeChange(u16,u16),
+}
 
 pub struct CecClient {
     connection: CecConnection,
-    audiosystem_status: KnownCecAudioStatus,
+    volume_ctrl: VolumeCtrl,
+    volume_steps: u16,
+    enable_volume_control: bool,
+    run: AtomicBool,
+    is_active: AtomicBool,
 }
+
+// CEC state is static because cec-rs has static callbacks, quick and hacky
+static DEVICE_VOLUME:AtomicU8 = AtomicU8::new(0);
+static LOCAL_VOLUME:AtomicU8 = AtomicU8::new(0);
+static VOLUME_IS_INIT:AtomicBool = AtomicBool::new(false);
+static DEVICE_IS_ON:AtomicBool = AtomicBool::new(false);
+static LOCAL_IS_ON:AtomicBool = AtomicBool::new(false);
 
 impl CecClient {
     fn on_key_press(keypress: CecKeypress) {
         trace!(
-            "onKeyPress: {:?}, keycode: {:?}, duration: {:?}",
+            "Key Press: {:?}, keycode: {:?}, duration: {:?}",
             keypress,
             keypress.keycode,
             keypress.duration
@@ -22,69 +46,206 @@ impl CecClient {
 
     fn on_command_received(command: CecCommand) {
         trace!(
-            "onCommandReceived:  opcode: {:?}, initiator: {:?}",
+            "Command Received:  opcode: {:?}, initiator: {:?}, params: {:?}",
             command.opcode,
-            command.initiator
+            command.initiator,
+            command.parameters.0
         );
+        // todo filter by initiator
+        match command.opcode {
+            CecOpcode::ReportPowerStatus => {
+                let power = command.parameters.0[0] > 0;
+                debug!("Got audio status: power: {power}");
+                DEVICE_IS_ON.store(power, Ordering::SeqCst);
+            },
+            CecOpcode::ReportAudioStatus => {
+                let mut volume = command.parameters.0[0];
+                debug!("Got audio status: volume: {volume}");
+                // When device is muted CEC reports that as volume + 0x80
+                if volume > 0x80 {
+                    volume -= 0x80;
+                    debug!("Device is muted: actual volume: {volume}");
+                }
+                DEVICE_VOLUME.store(volume, Ordering::SeqCst);
+                VOLUME_IS_INIT.store(true, Ordering::SeqCst);
+            },
+            CecOpcode::SetSystemAudioMode => {
+                let power = command.parameters.0[0] > 0;
+                debug!("Got audio status: power: {power}");
+                DEVICE_IS_ON.store(power, Ordering::SeqCst);
+            }
+            _ => ()
+        }
     }
 
     fn on_log_level(log_message: CecLogMessage) {
-        trace!(
-            "logMessageRecieved:  time: {}, level: {}, message: {}",
-            log_message.time.as_secs(),
-            log_message.level,
-            log_message.message
-        );
-    }
-
-    pub fn fetch_audiosystem_status(&self) -> KnownCecAudioStatus {
-        debug!("Fetching audiosystem status");
-        self.connection.audio_get_status()
-            .or_else(|err| {
-                error!("Fetch Audio Status failed with\n{err:?}");
-                Ok::<KnownCecAudioStatus, TryFromCecAudioStatusError>(self.audiosystem_status)
-            })
-            .inspect(|audio| {
-                debug!("New audiosystem status\n{audio:?}");
-                // self.audiosystem_status = *audio;
-            })
-            .unwrap()
-    }
-
-    pub fn get_audiosystem_status(&self) -> KnownCecAudioStatus {
-        self.audiosystem_status
-    }
-
-    pub fn update_volume(&self, new_volume: u16) -> KnownCecAudioStatus {
-        let old_volume = self.fetch_audiosystem_status().volume() as i32;
-        let diff = new_volume as i32 - old_volume;
-
-        if diff > 0 {
-            for _ in 0..diff {
-                let _ = self.connection.volume_up(true)
-                    .or_else(|err| {
-                        error!("Volume up failed, retrying\n{err:?}");
-                        self.connection.volume_up(true).or_else(|err| {
-                            error!("Volume up failed twice, not retrying\n{err:?}");
-                            Ok::<KnownCecAudioStatus, TryFromCecAudioStatusError>(self.audiosystem_status)
-                        })
-                    }).unwrap();
-            };
-        } else if diff < 0 {
-            for _ in diff..0 {
-                let _ = self.connection.volume_down(true)
-                    .or_else(|err| {
-                        error!("Volume down failed, retrying\n{err:?}");
-                        self.connection.volume_down(true).or_else(|err| {
-                            error!("Volume down failed twice, not retrying\n{err:?}");
-                            Ok::<KnownCecAudioStatus, TryFromCecAudioStatusError>(self.audiosystem_status)
-                        })
-                    }).unwrap();
-            };
-        } else {
-            return self.audiosystem_status
+        // TODO better filtering
+        if log_message.level != CecLogLevel::Debug {
+            trace!(
+                "Log Message Recieved:  time: {}, level: {}, message: {}",
+                log_message.time.as_secs(),
+                log_message.level,
+                log_message.message
+            );
         }
-        self.fetch_audiosystem_status()
+    }
+
+    pub fn get_power_status(&self) -> bool {
+        DEVICE_IS_ON.load(Ordering::SeqCst)
+    }
+
+    pub fn fetch_power_status(&self) {
+        debug!("Fetching audiosystem power status");
+        let command = CecCommand {
+            opcode: CecOpcode::GiveDevicePowerStatus,
+            initiator: CecLogicalAddress::Recordingdevice1,
+            destination: CecLogicalAddress::Audiosystem,
+            parameters: CecDatapacket(ArrayVec::new()),
+            transmit_timeout: Duration::from_secs(5),
+            ack: true,
+            eom: true,
+            opcode_set: true,
+        };
+        self.connection.transmit(command)
+            .or_else(|err| {
+                error!("Fetch audiosystem status failed with\n{err:?}");
+                CecConnectionResult::Ok(())
+            })
+            .unwrap();
+    }
+
+    fn convert_volume(volume:u8) -> u16 {
+        u16::try_from(
+            (VolumeCtrl::MAX_VOLUME as u32) * (volume as u32) / 100
+        ).unwrap_or_else(|_| VolumeCtrl::MAX_VOLUME)
+    }
+
+    pub fn get_volume(&self) -> u16 {
+        Self::convert_volume(DEVICE_VOLUME.load(Ordering::SeqCst))
+    }
+
+    pub fn fetch_volume(&self) {
+        debug!("Fetching audiosystem status");
+        if self.enable_volume_control {
+            let command = CecCommand {
+                opcode: CecOpcode::GiveAudioStatus,
+                initiator: CecLogicalAddress::Recordingdevice1,
+                destination: CecLogicalAddress::Audiosystem,
+                parameters: CecDatapacket(ArrayVec::new()),
+                transmit_timeout: Duration::from_secs(5),
+                ack: true,
+                eom: true,
+                opcode_set: true,
+            };
+            self.connection.transmit(command)
+                .or_else(|err| {
+                    error!("Fetch audiosystem status failed with\n{err:?}");
+                    CecConnectionResult::Ok(())
+                })
+                .unwrap();
+        }
+    }
+
+    pub fn is_volume_enabled(&self) -> bool {
+        self.enable_volume_control.clone()
+    }
+
+    pub fn is_volume_init(&self) -> bool {
+        VOLUME_IS_INIT.load(Ordering::SeqCst)
+    }
+
+    pub fn volume_up(&self) {
+        trace!("Send volume up");
+        if self.get_power_status() {
+            self.connection
+                .send_keypress(
+                    CecLogicalAddress::Audiosystem, 
+                    cec_rs::CecUserControlCode::VolumeUp, 
+                    false
+                )
+                .or_else(|err| {
+                    error!("Volume up send key press failed, retrying\n{err:?}");
+                    self.connection
+                        .send_keypress(
+                            CecLogicalAddress::Audiosystem, 
+                            cec_rs::CecUserControlCode::VolumeUp, 
+                            false
+                        )
+                        .or_else(|err| {
+                            error!("Volume up send key press twice, not retrying\n{err:?}");
+                            CecConnectionResult::Ok(())
+                        })
+                }).unwrap();
+        }
+    }
+
+    pub fn volume_down(&self) {
+        trace!("Send volume down");
+        if self.get_power_status() {
+            self.connection
+                .send_keypress(
+                    CecLogicalAddress::Audiosystem, 
+                    cec_rs::CecUserControlCode::VolumeDown, 
+                    false
+                )
+                .or_else(|err| {
+                    error!("Volume down send key press failed, retrying\n{err:?}");
+                    self.connection
+                    .send_keypress(
+                        CecLogicalAddress::Audiosystem, 
+                        cec_rs::CecUserControlCode::VolumeDown, 
+                        false
+                    )
+                        .or_else(|err| {
+                            error!("Volume down send key press twice, not retrying\n{err:?}");
+                            CecConnectionResult::Ok(())
+                        })
+                }).unwrap();
+        }
+    }
+
+    pub fn set_volume(&self, new_volume: u16) {
+        if self.enable_volume_control {
+            debug!("Updating volume");
+            if self.get_power_status() {
+                self.fetch_volume();
+                let mapped_new_volume = self.volume_ctrl.to_mapped(new_volume);
+                let old_volume = DEVICE_VOLUME.load(Ordering::SeqCst) as f64;
+                let mapped_old_volume = old_volume / 100f64;
+                let diff = mapped_new_volume - mapped_old_volume;
+                let steps = self.volume_ctrl.to_steps(diff, self.volume_steps);
+                debug!(
+                    "New volume {} maps to {:.3} - old volume {} maps to {:.3} = diff {:.3} steps {}",
+                    new_volume,
+                    mapped_new_volume,
+                    old_volume,
+                    mapped_old_volume,
+                    diff,
+                    steps,
+                );
+
+                if steps > 0 {
+                    for _ in 0..steps {
+                        self.volume_up();
+                    };
+                } else if steps < 0 {
+                    for _ in steps..0 {
+                        self.volume_down();
+                    };
+                } else {
+                    debug!("Volume is not changed, no action taken");
+                }
+                debug!("Volume updates sent over CEC");
+            } else {
+                debug!("Device is off, cannot update volume");
+            }
+        } else {
+            debug!("Volume control disabled, no action taken");
+        }
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.is_active.load(Ordering::SeqCst)
     }
 
     pub fn activate_source(&self) {
@@ -100,6 +261,7 @@ impl CecClient {
                     })
             })
             .unwrap();
+        
         debug!("Activating source");
         self.connection.set_active_source(self.connection.0.device_types.0[0])
             .or_else(|err| {
@@ -111,12 +273,19 @@ impl CecClient {
                     })
             })
             .unwrap();
+        
+        self.is_active.store(true, Ordering::SeqCst);
     }
 
     pub fn deactivate_source(&self) {
         debug!("Setting inactive source");
-        debug!("Deactivating source and setting to playback device");
-        self.connection.set_active_source(CecDeviceType::PlaybackDevice)
+        self.is_active.store(false, Ordering::SeqCst);
+
+        // todo with some devices this will always return standby, replace with custom transmit
+        debug!("Deactivating source and setting to playback device if on");
+        if self.connection.get_device_power_status(CecLogicalAddress::Playbackdevice1) == CecPowerStatus::On {
+            debug!("Playback is on, setting as active");
+            self.connection.set_active_source(CecDeviceType::PlaybackDevice)
             .or_else(|err| {
                 error!("Activating source failed, retrying\n{err:?}");
                 self.connection.set_active_source(CecDeviceType::PlaybackDevice)
@@ -126,6 +295,8 @@ impl CecClient {
                     })
             })
             .unwrap();
+        }
+
         debug!("Turning off audiosystem");
         self.connection.send_standby_devices(CecLogicalAddress::Audiosystem)
             .or_else(|err| {
@@ -139,9 +310,106 @@ impl CecClient {
             .unwrap();
     }
 
+    /// listens for commands and publishes to subscription
+    /// returns a function to close connection which itself returns a JoinSet
+    pub fn run(cec:Arc<CecClient>, sender: UnboundedSender<CecEvent>) -> Box<dyn FnOnce() -> JoinSet<()> + Send> {
+        info!("Running CEC Client");
+        let mut set = JoinSet::new();
+        cec.run.store(true, Ordering::SeqCst);
+
+        // listen for device power changes
+        let power_cec = cec.clone();
+        let power_sender = sender.clone();
+        set.spawn(async move {
+            while power_cec.run.load(Ordering::SeqCst) {
+                let power = DEVICE_IS_ON.load(Ordering::SeqCst);
+                let current_power = LOCAL_IS_ON.load(Ordering::SeqCst);
+                
+                if power != current_power {
+                    debug!("Power status changed from {current_power} to {power}");
+                    LOCAL_IS_ON.store(power, Ordering::SeqCst);
+                    power_sender.send(CecEvent::PowerIsOnChange(power)).unwrap();
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+
+        // Sync volume initially
+        let init_volume_cec = cec.clone();
+        let init_volume_sender = sender.clone();
+        set.spawn(async move {
+            debug!("Initial sync of volume from device");
+            init_volume_cec.fetch_volume();
+            let mut is_uninit = true;
+            while is_uninit {
+                let is_init = VOLUME_IS_INIT.load(Ordering::SeqCst);
+                if is_init {
+                    let volume = DEVICE_VOLUME.load(Ordering::SeqCst);
+                    debug!("Volume intialized to {volume}");
+                    LOCAL_VOLUME.store(volume, Ordering::SeqCst);
+                    init_volume_sender.send(
+                        CecEvent::VolumeChange(Self::convert_volume(volume),Self::convert_volume(volume))
+                    ).unwrap();
+                    is_uninit = false;
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+
+        // Listen for device volume changes
+        let volume_cec = cec.clone();
+        let volume_sender = sender.clone();
+        set.spawn(async move {
+            if volume_cec.enable_volume_control {
+                // ask if source has changed volume once per second(ish) since that is not broadcast
+                const AUDIO_POLL_FREQ: u64 = 200;
+                const LOOP_SLEEP_MILLIS: u64 = 5;
+                debug!("Volume change polling freq: {} ms", LOOP_SLEEP_MILLIS * AUDIO_POLL_FREQ);
+                let mut loops: u64 = 0;
+                while volume_cec.run.load(Ordering::SeqCst) {
+                    if volume_cec.is_active() {
+                        loops += 1;
+                        if loops < AUDIO_POLL_FREQ {
+                            let volume = DEVICE_VOLUME.load(Ordering::SeqCst);
+                            let current_volume = LOCAL_VOLUME.load(Ordering::SeqCst);
+                            if volume != current_volume {
+                                debug!("Volume changed from {current_volume} to {volume}");
+                                LOCAL_VOLUME.store(volume, Ordering::SeqCst);
+                                volume_sender.send(
+                                    CecEvent::VolumeChange(
+                                        Self::convert_volume(current_volume),Self::convert_volume(volume)
+                                    )
+                                ).unwrap();
+                            }
+                            let _ = tokio::time::sleep(Duration::from_millis(LOOP_SLEEP_MILLIS)).await;
+                        } else {
+                            loops = 0;
+                            volume_cec.fetch_volume();
+                        }
+                    }
+                    tokio::task::yield_now().await;
+                }
+            }
+        });
+
+        // Return boxed function to close connection and join handles of tasks
+        Box::new(move || {
+            info!("Shutting CEC Client down");
+            debug!("Stopping task loops");
+            cec.run.store(false, Ordering::SeqCst);
+            debug!("Deactivating");
+            cec.deactivate_source();
+            info!("CEC Client closed");
+            set
+        })
+    }
+
     pub fn new/*<F>*/(
         device_name: String,
-        port: CString
+        port: CString,
+        volume_ctrl: VolumeCtrl,
+        volume_steps: u16,
+        enable_volume_control: bool, 
     ) -> Arc<Self>
     // where
     //     F: FnOnce() -> Box<dyn Sink> + Send + 'static,
@@ -153,24 +421,33 @@ impl CecClient {
         let cfg = CecConnectionCfgBuilder::default()
             .port(port)
             .device_name(device_name)
-            // .physical_address(1100)
             .key_press_callback(Box::new(Self::on_key_press))
             .command_received_callback(Box::new(Self::on_command_received))
             .log_message_callback(Box::new(Self::on_log_level))
             .device_types(CecDeviceTypeVec::new(CecDeviceType::RecordingDevice))
             .wake_devices(default_devices.clone())
-            .autowake_avr(true)
             .power_off_devices(default_devices)
             .power_off_on_standby(false)
-            .tv_vendor(CecVendorId::Samsung.repr())
             .activate_source(false)
             .open_timeout(Duration::from_secs(10))
             .adapter_type(CecAdapterType::Linux)
             .build()
             .unwrap();
         let connection = cfg.open().unwrap();
-        info!("CEC connection opened");
-        let cec = Self { connection, audiosystem_status: KnownCecAudioStatus::new(0, true)  };
+        info!("CEC connection opened, volume control {enable_volume_control}");
+        let cec = Self { 
+            connection, 
+            volume_ctrl,
+            volume_steps,
+            enable_volume_control, 
+            run: AtomicBool::new(false),
+            is_active: AtomicBool::new(false)  
+        };
+        // get intial values
+        cec.fetch_power_status();
+        if enable_volume_control {
+            cec.fetch_volume();
+        }
         Arc::new(cec)
     }
 }

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -165,6 +165,7 @@ impl Default for PlayerConfig {
 pub enum VolumeCtrl {
     Cubic(f64),
     Fixed,
+    LinearPass,
     Linear,
     Log(f64),
 }
@@ -194,6 +195,7 @@ impl VolumeCtrl {
             "cubic" => Ok(Cubic(db_range)),
             "fixed" => Ok(Fixed),
             "linear" => Ok(Linear),
+            "linearpass" => Ok(LinearPass),
             "log" => Ok(Log(db_range)),
             _ => Err(()),
         }

--- a/playback/src/mixer/mappings.rs
+++ b/playback/src/mixer/mappings.rs
@@ -4,6 +4,7 @@ use crate::player::db_to_ratio;
 pub trait MappedCtrl {
     fn to_mapped(&self, volume: u16) -> f64;
     fn as_unmapped(&self, mapped_volume: f64) -> u16;
+    fn to_steps(&self, mapped_volume: f64, steps: u16) -> i32;
 
     fn db_range(&self) -> f64;
     fn set_db_range(&mut self, new_db_range: f64);
@@ -77,10 +78,15 @@ impl MappedCtrl for VolumeCtrl {
         (unmapped_volume * Self::MAX_VOLUME as f64) as u16
     }
 
+    fn to_steps(&self, mapped_volume: f64, steps: u16) -> i32 {
+        f64::round(mapped_volume * (steps as f64)) as i32
+    }
+    
     fn db_range(&self) -> f64 {
         match *self {
             Self::Fixed => 0.0,
             Self::Linear => Self::DEFAULT_DB_RANGE, // arbitrary, could be anything > 0
+            Self::LinearPass => Self::DEFAULT_DB_RANGE, // arbitrary, could be anything > 0
             Self::Log(db_range) | Self::Cubic(db_range) => db_range,
         }
     }
@@ -95,7 +101,7 @@ impl MappedCtrl for VolumeCtrl {
     }
 
     fn range_ok(&self) -> bool {
-        self.db_range() > 0.0 || matches!(self, Self::Fixed | Self::Linear)
+        self.db_range() > 0.0 || matches!(self, Self::Fixed | Self::Linear | Self::LinearPass)
     }
 }
 

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spotipi-protocol"
-version = "0.6.0-dev"
+version = "0.7.0"
 rust-version.workspace = true
 authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"

--- a/update_version.sh
+++ b/update_version.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+DRY_RUN='false'
+
+WORKINGDIR="$( cd "$(dirname "$0")" ; pwd -P )"
+cd $WORKINGDIR
+
+# Order: dependencies first (so "spotipi" using everything before it goes last)
+crates=( "protocol" "oauth" "core" "discovery" "audio" "metadata" "playback" "connect" "spotipi" )
+
+function replace_in_file() {
+  OS=`uname`
+  shopt -s nocasematch
+  case "$OS" in
+    darwin)
+      # for macOS
+      sed -i '' -e "$1" "$2"
+      ;;
+    *)
+      # for Linux and Windows
+      sed -i'' -e "$1" "$2"
+      ;;
+  esac
+}
+
+function run {
+  for CRATE in "${crates[@]}"
+  do
+    if [ "$CRATE" = "spotipi" ]
+    then
+      CRATE_DIR=''
+    else
+      CRATE_DIR=$CRATE
+    fi
+    crate_path="$WORKINGDIR/$CRATE_DIR/Cargo.toml"
+    crate_path=${crate_path//\/\///}
+    $(replace_in_file "s/^version.*/version = \"$1\"/g" "$crate_path")
+    echo "Path is $crate_path"
+    if [ "$CRATE" = "spotipi" ]
+    then
+      echo "Updating lockfile"
+      if [ "$DRY_RUN" = 'true' ] ; then
+        cargo update --dry-run
+        # git add . && git commit --dry-run -a -m "Update Cargo.lock"
+      else
+        cargo update
+        # git add . && git commit -a -m "Update Cargo.lock"
+      fi
+    fi
+  done
+}
+
+#Set Script Name variable
+SCRIPT=`basename ${BASH_SOURCE[0]}`
+
+print_usage () {
+  local l_MSG=$1
+  if [ ! -z "${l_MSG}" ]; then
+    echo "Usage Error: $l_MSG"
+  fi
+  echo "Usage: $SCRIPT <args> <version>"
+  echo "  where <version> specifies the version number in semver format, eg. 1.0.1"
+  echo "Recognized optional command line arguments"
+  echo "--dry-run -- Test the script before making live changes"
+  exit 1
+}
+
+### check number of command line arguments
+NUMARGS=$#
+if [ $NUMARGS -eq 0 ]; then
+  print_usage 'No command line arguments specified'
+fi
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+      --dry-run)
+        DRY_RUN='true'
+        shift
+        ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+# First argument is new version number.
+run $1


### PR DESCRIPTION
added LinearPass option to VolumeCtrl
this will have the cec client control volume for tv or receiver otherwise CEC only controls power and source
this also forces the volume_steps to 74 as a default changed to power on device when you first connect, not when you play added listener to disconnect player when device is turned off added/changed additional defaults with flags to change at runtime updated service to reflect new settings
had to replace some of the cec convenience methods with custom transmits because they don't work without a tv present